### PR TITLE
refactor(engine): encapsulate engine access and optimize schema mapping performance

### DIFF
--- a/data/schema_mapping_eval/run_schema_mapping.py
+++ b/data/schema_mapping_eval/run_schema_mapping.py
@@ -16,7 +16,8 @@ except Exception:
     pass
 
 try:
-    from src.Engine import SchemaMapEngine
+    from src.Engine import get_schema_engine
+    SchemaMapEngine = get_schema_engine()
 except Exception as e:
     print("[ERROR] Cannot import SchemaMapEngine from src.Engine:",
           e,
@@ -30,14 +31,15 @@ def parse_args():
     p.add_argument(
         "-i",
         "--input",
-        default=os.getenv("CLINICAL_DATA_PATH", "test.csv"),
+        default=os.getenv("CLINICAL_DATA_PATH",
+                          "data/schema/cBioPortal_all_clinicalData_2024.tsv"),
         help=
-        "Path to clinical data CSV (default: $CLINICAL_DATA_PATH or test.csv)",
+        "Path to clinical data CSV (default: $CLINICAL_DATA_PATH or data/schema/cBioPortal_all_clinicalData_2024.tsv)",
     )
     p.add_argument(
         "--mode",
         default=os.getenv("SCHEMA_MODE", "manual"),
-        choices=["manual", "auto", "hybrid"],
+        choices=["manual", "auto"],
         help='Mapping mode (default: $SCHEMA_MODE or "manual")',
     )
     p.add_argument(
@@ -51,16 +53,28 @@ def parse_args():
 
 def main():
     args = parse_args()
+
+    if not os.path.exists(args.input):
+        print(f"[ERROR] input file not found: {args.input}", file=sys.stderr)
+        sys.exit(2)
+
     start = datetime.now()
     print(f"[INFO] Start schema mapping at {start:%Y-%m-%d %H:%M:%S}")
     print(f"[INFO] input={args.input} mode={args.mode} top_k={args.top_k}")
 
-    engine = SchemaMapEngine(
-        clinical_data_path=args.input,
-        mode=args.mode,
-        top_k=args.top_k,
-    )
-    engine.run_schema_mapping()
+    try:
+        engine = SchemaMapEngine(
+            clinical_data_path=args.input,
+            mode=args.mode,
+            top_k=args.top_k,
+        )
+        df = engine.run_schema_mapping()
+        out_file = engine.output_file.replace(".csv", f"_{engine.mode}.csv")
+        print(f"[INFO] Results saved to: {out_file}")
+        print(f"[INFO] Mapped columns: {len(df)}")
+    except Exception as e:
+        print(f"[ERROR] schema mapping failed: {e}", file=sys.stderr)
+        sys.exit(3)
 
     end = datetime.now()
     print(f"[INFO] Done at {end:%Y-%m-%d %H:%M:%S} (elapsed: {end - start})")

--- a/demo_nb/ontology_mapper_workflow.ipynb
+++ b/demo_nb/ontology_mapper_workflow.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "012e2ab8",
    "metadata": {},
    "outputs": [
@@ -10,14 +10,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/home/lcc/projects/MetaHarmonizer\n"
+      "/home/lcc/projects/MetaHarmonizer-New\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/lcc/miniconda3/envs/py310/lib/python3.10/site-packages/IPython/core/magics/osm.py:417: UserWarning: This is now an optional IPython functionality, setting dhist requires you to install the `pickleshare` library.\n",
+      "/home/lcc/miniconda3/envs/demo_env/lib/python3.10/site-packages/IPython/core/magics/osm.py:417: UserWarning: This is now an optional IPython functionality, setting dhist requires you to install the `pickleshare` library.\n",
       "  self.shell.db['dhist'] = compress_dhist(dhist)[-100:]\n"
      ]
     }
@@ -58,34 +58,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "f5b39b4c",
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/lcc/miniconda3/envs/py310/lib/python3.10/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n",
-      "/home/lcc/miniconda3/envs/py310/lib/python3.10/site-packages/fuzzywuzzy/fuzz.py:11: UserWarning: Using slow pure-python SequenceMatcher. Install python-Levenshtein to remove this warning\n",
-      "  warnings.warn('Using slow pure-python SequenceMatcher. Install python-Levenshtein to remove this warning')\n",
-      "[nltk_data] Downloading package punkt to /home/lcc/nltk_data...\n",
-      "[nltk_data]   Package punkt is already up-to-date!\n",
-      "[nltk_data] Downloading package wordnet to /home/lcc/nltk_data...\n",
-      "[nltk_data]   Package wordnet is already up-to-date!\n",
-      "[nltk_data] Downloading package punkt to /home/lcc/nltk_data...\n",
-      "[nltk_data]   Package punkt is already up-to-date!\n",
-      "[nltk_data] Downloading package stopwords to /home/lcc/nltk_data...\n",
-      "[nltk_data]   Package stopwords is already up-to-date!\n",
-      "[nltk_data] Downloading package wordnet to /home/lcc/nltk_data...\n",
-      "[nltk_data]   Package wordnet is already up-to-date!\n"
-     ]
-    },
-    {
      "data": {
       "text/plain": [
-       "<module 'src.Engine.ontology_mapping_engine' from '/home/lcc/projects/MetaHarmonizer/src/Engine/ontology_mapping_engine.py'>"
+       "<module 'src.models.ontology_mapper_bi_encoder' from '/home/lcc/projects/MetaHarmonizer-New/src/models/ontology_mapper_bi_encoder.py'>"
       ]
      },
      "execution_count": 3,
@@ -106,19 +86,20 @@
     "from src.models import ontology_mapper_bi_encoder as om_bi\n",
     "\n",
     "# Import the engine that handles pipeline logic and integrates the mappers\n",
-    "from src.Engine import ontology_mapping_engine as ome\n",
+    "from src.Engine import get_ontology_engine\n",
+    "\n",
+    "OntoMapEngine = get_ontology_engine()\n",
     "\n",
     "# Reload modules to reflect any code updates during development (useful in Jupyter)\n",
     "reload(om_st)\n",
     "reload(om_lm)\n",
     "reload(om_rag)\n",
-    "reload(om_bi)\n",
-    "reload(ome)"
+    "reload(om_bi)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "9b3ec51a",
    "metadata": {},
    "outputs": [],
@@ -183,7 +164,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "e041f396",
    "metadata": {},
    "outputs": [
@@ -191,139 +172,868 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Initialized OntoMap Engine module\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Running Ontology Mapping\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Separating exact and non-exact matches\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replacing shortNames using rule-based name mapping\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: ACC → Adrenocortical Carcinoma\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: ACYC → Adenoid Cystic Carcinoma\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: AML → Acute Myeloid Leukemia\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: ANSC → Anal Squamous Cell Carcinoma\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: APAD → Appendiceal Adenocarcinoma\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: ASPS → Alveolar Soft Part Sarcoma\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: ATRT → Atypical Teratoid/Rhabdoid Tumor\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: BLCA → Bladder Urothelial Carcinoma\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: BLL → B-Lymphoblastic Leukemia/Lymphoma\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: BRCA → Invasive Breast Carcinoma\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: CCOV → Clear Cell Ovarian Cancer\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: CCRCC → Renal Clear Cell Carcinoma\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: CESC → Cervical Squamous Cell Carcinoma\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: CHOL → Cholangiocarcinoma\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: CML → Chronic Myelogenous Leukemia\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: CMML → Chronic Myelomonocytic Leukemia\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: COAD → Colon Adenocarcinoma\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: CSCC → Cutaneous Squamous Cell Carcinoma\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: DIPG → Diffuse Intrinsic Pontine Glioma\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: EMBT → Embryonal Tumor\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: EPM → Ependymoma\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: ES → Ewing Sarcoma\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: ESCA → Esophageal Adenocarcinoma\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: FL → Follicular Lymphoma\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: GB → Glioblastoma\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: GBC → Gallbladder Cancer\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: GBM → Glioblastoma Multiforme\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: GINET → Gastrointestinal Neuroendocrine Tumors\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: GIST → Gastrointestinal Stromal Tumor\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: HCC → Hepatocellular Carcinoma\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: HGGNOS → High-Grade Glioma, NOS\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: HGSOC → High-Grade Serous Ovarian Cancer\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: HNSC → Head and Neck Squamous Cell Carcinoma\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: IDC → Breast Invasive Ductal Carcinoma\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: LGSOC → Low-Grade Serous Ovarian Cancer\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: LIHB → Hepatoblastoma\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: LNET → Lung Neuroendocrine Tumor\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: LUAD → Lung Adenocarcinoma\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: LUSC → Lung Squamous Cell Carcinoma\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: MBL → Medulloblastoma\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: MDS → Myelodysplastic Syndromes\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: MGUS → Monoclonal Gammopathy of Undetermined Significance\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: NBL → Neuroblastoma\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: NHL → Non-Hodgkin Lymphoma\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: NSCLC → Non-Small Cell Lung Cancer\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: OS → Osteosarcoma\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: PAAD → Pancreatic Adenocarcinoma\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: PANET → Pancreatic Neuroendocrine Tumor\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: PAST → Pilocytic Astrocytoma\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: PLMESO → Pleural Mesothelioma\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: PNET → Primitive Neuroectodermal Tumor\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: PRAD → Prostate Adenocarcinoma\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: RBL → Retinoblastoma\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: READ → Rectal Adenocarcinoma\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: RMS → Rhabdomyosarcoma\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: SCLC → Small Cell Lung Cancer\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: SKCM → Cutaneous Melanoma\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: STAD → Stomach Adenocarcinoma\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: TGCT → Tenosynovial Giant Cell Tumor Diffuse Type\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: THPA → Papillary Thyroid Cancer\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: THPD → Poorly Differentiated Thyroid Cancer\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: THYM → Thymoma\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: TLL → T-Lymphoblastic Leukemia/Lymphoma\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: UCS → Uterine Carcinosarcoma/Uterine Malignant Mixed Mullerian Tumor\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: UM → Uveal Melanoma\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapEngine: Replaced: WT → Wilms' Tumor\n",
-      "09/07/2025 03:37:15 PM - INFO - OntoMapST: Initialized OntoMap Sentence Transformer module\n"
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Initialized OntoMap Engine module\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Running Ontology Mapping\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Separating exact and non-exact matches\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replacing shortNames using rule-based name mapping\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: ACC → Adrenocortical Carcinoma\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: ACYC → Adenoid Cystic Carcinoma\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: AML → Acute Myeloid Leukemia\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: ANSC → Anal Squamous Cell Carcinoma\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: APAD → Appendiceal Adenocarcinoma\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: ASPS → Alveolar Soft Part Sarcoma\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: ATRT → Atypical Teratoid/Rhabdoid Tumor\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: BLCA → Bladder Urothelial Carcinoma\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: BLL → B-Lymphoblastic Leukemia/Lymphoma\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: BRCA → Invasive Breast Carcinoma\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: CCOV → Clear Cell Ovarian Cancer\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: CCRCC → Renal Clear Cell Carcinoma\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: CESC → Cervical Squamous Cell Carcinoma\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: CHOL → Cholangiocarcinoma\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: CML → Chronic Myelogenous Leukemia\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: CMML → Chronic Myelomonocytic Leukemia\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: COAD → Colon Adenocarcinoma\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: CSCC → Cutaneous Squamous Cell Carcinoma\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: DIPG → Diffuse Intrinsic Pontine Glioma\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: EMBT → Embryonal Tumor\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: EPM → Ependymoma\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: ES → Ewing Sarcoma\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: ESCA → Esophageal Adenocarcinoma\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: FL → Follicular Lymphoma\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: GB → Glioblastoma\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: GBC → Gallbladder Cancer\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: GBM → Glioblastoma Multiforme\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: GINET → Gastrointestinal Neuroendocrine Tumors\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: GIST → Gastrointestinal Stromal Tumor\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: HCC → Hepatocellular Carcinoma\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: HGGNOS → High-Grade Glioma, NOS\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: HGSOC → High-Grade Serous Ovarian Cancer\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: HNSC → Head and Neck Squamous Cell Carcinoma\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: IDC → Breast Invasive Ductal Carcinoma\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: LGSOC → Low-Grade Serous Ovarian Cancer\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: LIHB → Hepatoblastoma\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: LNET → Lung Neuroendocrine Tumor\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: LUAD → Lung Adenocarcinoma\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: LUSC → Lung Squamous Cell Carcinoma\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: MBL → Medulloblastoma\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: MDS → Myelodysplastic Syndromes\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: MGUS → Monoclonal Gammopathy of Undetermined Significance\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: NBL → Neuroblastoma\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: NHL → Non-Hodgkin Lymphoma\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: NSCLC → Non-Small Cell Lung Cancer\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: OS → Osteosarcoma\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: PAAD → Pancreatic Adenocarcinoma\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: PANET → Pancreatic Neuroendocrine Tumor\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: PAST → Pilocytic Astrocytoma\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: PLMESO → Pleural Mesothelioma\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: PNET → Primitive Neuroectodermal Tumor\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: PRAD → Prostate Adenocarcinoma\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: RBL → Retinoblastoma\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: READ → Rectal Adenocarcinoma\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: RMS → Rhabdomyosarcoma\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: SCLC → Small Cell Lung Cancer\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: SKCM → Cutaneous Melanoma\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: STAD → Stomach Adenocarcinoma\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: TGCT → Tenosynovial Giant Cell Tumor Diffuse Type\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: THPA → Papillary Thyroid Cancer\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: THPD → Poorly Differentiated Thyroid Cancer\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: THYM → Thymoma\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: TLL → T-Lymphoblastic Leukemia/Lymphoma\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: UCS → Uterine Carcinosarcoma/Uterine Malignant Mixed Mullerian Tumor\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: UM → Uveal Melanoma\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapEngine: Replaced: WT → Wilms' Tumor\n",
+      "06/10/2025 05:17:14 PM - INFO - OntoMapST: Initialized OntoMap Sentence Transformer module\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "No sentence-transformers model found with name model_cache/mt-sap-bert. Creating a new one with mean pooling.\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 22.10it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 62.87it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 65.62it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 73.16it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 75.38it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 71.31it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 70.76it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 72.96it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 75.97it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 73.88it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 70.75it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 70.94it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 64.52it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 70.14it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 71.41it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 72.47it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 72.09it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 70.39it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 67.68it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 63.89it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 65.04it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 74.73it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 70.41it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 66.82it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 69.14it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 71.79it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 75.08it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 77.56it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 74.76it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 62.99it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 73.90it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 72.35it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 75.28it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 62.10it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 67.50it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 76.09it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 65.62it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 59.77it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 70.50it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 72.79it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 65.48it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 57.60it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 61.38it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 68.77it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 66.57it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 67.47it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 71.19it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 70.69it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 63.53it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 72.88it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 71.44it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 57.30it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 65.84it/s]\n",
-      "Batches: 100%|██████████| 16/16 [00:00<00:00, 63.57it/s]\n",
-      "Batches: 100%|██████████| 8/8 [00:00<00:00, 62.21it/s]\n",
+      "No sentence-transformers model found with name model_cache/mt-sap-bert. Creating a new one with mean pooling.\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "206a1f3ae2e042e3919b0c73397218a9",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/lcc/miniconda3/envs/demo_env/lib/python3.10/site-packages/torch/nn/modules/module.py:1762: FutureWarning: `encoder_attention_mask` is deprecated and will be removed in version 4.55.0 for `BertSdpaSelfAttention.forward`.\n",
+      "  return forward_call(*args, **kwargs)\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3cde3b6058d5450db975fb80bd5725bf",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "77442912cb49466dac29ceaf24c602d3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ab792bfc5b9541fcbf11038b5d90c7bf",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "868ab8ec90c7456ab80b2ba57c8a66ca",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ff8dc39f99db428f8993f9ff89d72d29",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a2e0d2d4a674462299f9d9b85be06fc6",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b47730c41c2243578fcd162d9916f669",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e347bac658b04987af4392226dd36dd7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "fc27264c92bc47f4a128671add52d132",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9517546908474591aeaf2a7c968410a5",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1b4bb37f8aa64ebe9263832b00c5e2de",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "29d2b48316964de18e8f9ccb46e7ce86",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1b651848e6d54cecbab9374e6f403cf5",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "21933ca6499845f3ab1f7e661b30df2d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ae3ef963b6e14d00840a0166e2ec6f78",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3d28268013024cf7954af54e8c6c7b8d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "69f7d2859d1642509cd06b8494e9e315",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4eb8d382654541b7b99e513c4a1e60ed",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "62341160207148af98559877f0a775b8",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9d822560968641ce86a93ae617b8d25b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "71dc0c50383c4ad9922bcfa338ee146a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7d0ce9cf3bbd4c6282f3a0361d968ec0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ccdd90f2f3864f548f9744fbf3dbdd1f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f0ac71c1747948eab6973b241c6eecad",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "69fe04fe738d4968b7d5f4010fb60740",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6fc4825f58774736bf5c624b807ca8b7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6e82818c68bb4f7daf9dbbfca9ca8ba3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "919721e97dee4f959da42bb1ce13c7ae",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "df3c5fdbbcc74a4ab77b899e5fed29c9",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5d966f20dd43433c86da4fb499c46b55",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6257a5edfac04e1789962d1371e61787",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9d50b451e0d24ff1b8a8b53d314335fe",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3bf413d3145340189e3d88259311c556",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "85f118469a9f4ba681709a910993ffff",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d01ffcd70fa144488306b882d6c3625a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "376d5d8006344fe5bf73f5392f786819",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2583355a0cb64583834bd6f1530078c1",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c0d715b9cf7a40c8bf92cd5de8f9db4c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1362d4805fce4a4f878ac49d8cbe06ac",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2671a893fc2144b4abe1ca89eb391c5c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "edf430febc05490dbcee4230a611d716",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3f10735e96f24645b9503d65fcb4092f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c417df0611a846e798b72a0de7bcf2a6",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ca695116bdfc4d07ba89a113f6e182db",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "989013eb16664d50a1f64a8e9fadfda4",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2f02c508f59c45df831b89379e4b4336",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c6ea6415f8d34125b5b457ee7b0f798d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f1a629a373f94ba1a52cb16c1c4b4bc1",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e8ce36db9ddb41328630d8ebffa8d6ba",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0cf2d92a1f824e379083de144f349fdd",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0aa8e995bbbe4032ade55f4a3def5842",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "38e94976d6304c6a874a8b01974796c2",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6afe27069fc241578519a538954d3194",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/16 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1d739ff42e5d47c896e5c69cce70e07e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/8 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
       "No sentence-transformers model found with name cambridgeltl/SapBERT-from-PubMedBERT-fulltext-mean-token. Creating a new one with mean pooling.\n"
      ]
     }
@@ -340,20 +1050,20 @@
     "# Returns: DF with original values, curated ontology values, match levels, stage, and top k matches with scores\n",
     "\n",
     "other_params = {\"test_or_prod\": \"test\"}\n",
-    "onto_engine_large = ome.OntoMapEngine(method='mt-sap-bert',\n",
+    "onto_engine_large = OntoMapEngine(method='mt-sap-bert',\n",
     "                                      category='disease',\n",
-    "                                      topk=20,\n",
+    "                                      topk=5,\n",
     "                                      query=query_list,\n",
     "                                      corpus=large_corpus_list,\n",
     "                                      cura_map=cura_map,\n",
     "                                      om_strategy='st',\n",
     "                                      **other_params)\n",
-    "st_sapbert_disease_top20_result = onto_engine_large.run()"
+    "st_sapbert_disease_top5_result = onto_engine_large.run()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "04c328ca",
    "metadata": {},
    "outputs": [
@@ -362,16 +1072,16 @@
      "output_type": "stream",
      "text": [
       "  Accuracy Level   Accuracy\n",
-      "0    Top 1 Match  75.241779\n",
-      "1  Top 3 Matches  84.526112\n",
-      "2  Top 5 Matches  87.685364\n"
+      "0    Top 1 Match  75.562701\n",
+      "1  Top 3 Matches  84.694534\n",
+      "2  Top 5 Matches  87.781350\n"
      ]
     }
    ],
    "source": [
     "# Calculate Top1, Top3, and Top5 accuracy for the generated results\n",
     "\n",
-    "st_sapbert_accuracy_df = calc.calc_accuracy(st_sapbert_disease_top20_result)\n",
+    "st_sapbert_accuracy_df = calc.calc_accuracy(st_sapbert_disease_top5_result)\n",
     "print(st_sapbert_accuracy_df)"
    ]
   },
@@ -384,8 +1094,8 @@
    "source": [
     "# Save the results to a CSV file for further analysis or reporting. Optional.\n",
     "\n",
-    "st_sapbert_disease_top20_result.to_csv(\n",
-    "    \"st_sapbert_disease_top20_result.csv\",\n",
+    "st_sapbert_disease_top5_result.to_csv(\n",
+    "    \"st_sapbert_disease_top5_result.csv\",\n",
     "    index=False)"
    ]
   },
@@ -399,7 +1109,7 @@
     "# RAG Strategy: Need corpus_df for concept retrieval.\n",
     "# Example: \n",
     "other_params = {\"test_or_prod\": \"test\"}\n",
-    "onto_engine_large = ome.OntoMapEngine(method='pubmed-bert',\n",
+    "onto_engine_large = OntoMapEngine(method='pubmed-bert',\n",
     "                                      category='disease',\n",
     "                                      topk=5,\n",
     "                                      query=query_list,\n",
@@ -413,7 +1123,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "4731235a",
    "metadata": {},
    "outputs": [
@@ -1662,7 +2372,7 @@
     "\n",
     "# run rag_bie strategy:\n",
     "other_params = {\"test_or_prod\": \"test\"}\n",
-    "onto_engine_large = ome.OntoMapEngine(method='pubmed-bert',\n",
+    "onto_engine_large = OntoMapEngine(method='pubmed-bert',\n",
     "                                      category='disease',\n",
     "                                      topk=20,\n",
     "                                      query=query_list,\n",

--- a/demo_nb/schema_mapper_workflow.ipynb
+++ b/demo_nb/schema_mapper_workflow.ipynb
@@ -42,14 +42,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "80dc370a",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Import the SchemaMapEngine class\n",
     "\n",
-    "from src.Engine import SchemaMapEngine"
+    "from src.Engine import get_schema_engine\n",
+    "\n",
+    "SchemaMapEngine = get_schema_engine()"
    ]
   },
   {

--- a/readme.md
+++ b/readme.md
@@ -71,7 +71,7 @@ from importlib import reload
 nest_asyncio.apply()
 
 ## Import the models/engine for ontology mapping
-from src.Engine import ontology_mapping_engine as ome
+from src.Engine import get_ontology_engine
 from src.models import ontology_mapper_st as om_st
 from src.models import ontology_mapper_lm as om_lm
 from src.models import ontology_mapper_rag as om_rag
@@ -82,7 +82,8 @@ reload(om_st)
 reload(om_lm)
 reload(om_rag)
 reload(om_bi)
-reload(ome)
+
+OntoMapEngine = get_ontology_engine()
 
 ## Import useful utilities 
 from src.models.calc_stats import CalcStats # for calculating accuracy (testing) 
@@ -90,7 +91,7 @@ from src.utils.cleanup_vector_store import cleanup_vector_store # for cleaning u
 
 ## Now you must initialize the engine
 other_params = {"test_or_prod": "test"}
-onto_engine_large = ome.OntoMapEngine(method='sap-bert',
+onto_engine_large = OntoMapEngine(method='sap-bert',
                                       category='disease',
                                       topk=5,
                                       query=query_list,
@@ -123,7 +124,9 @@ results_engine_testing = onto_engine_large.run()
 
 2. Schema mapping
 ```python
-from src.Engine.schema_mapping_engine import SchemaMapEngine
+from src.Engine import get_schema_engine
+
+SchemaMapEngine = get_schema_engine()
 
 # Initialize the engine
 engine = SchemaMapEngine(

--- a/requirements_sm.txt
+++ b/requirements_sm.txt
@@ -1,0 +1,19 @@
+# Core data and ML
+pandas
+numpy
+torch
+sentence-transformers
+scikit-learn
+
+# Fuzzy matching
+rapidfuzz
+
+# Notebook and utils (optional, required for Jupyter/Notebook environments)
+jupyter
+ipython
+ipywidgets
+tqdm
+
+# Web and IO
+requests
+openpyxl

--- a/src/Engine/__init__.py
+++ b/src/Engine/__init__.py
@@ -1,2 +1,8 @@
-from .ontology_mapping_engine import OntoMapEngine
-from .schema_mapping_engine import SchemaMapEngine
+def get_schema_engine():
+    from .schema_mapping_engine import SchemaMapEngine
+    return SchemaMapEngine
+
+
+def get_ontology_engine():
+    from .ontology_mapping_engine import OntoMapEngine
+    return OntoMapEngine

--- a/src/utils/invalid_column_utils.py
+++ b/src/utils/invalid_column_utils.py
@@ -61,7 +61,7 @@ def is_id_column(col: str) -> bool:
     Heuristic: if >90% of sampled non-null values are alphanumeric strings
     of length 5-20 without spaces or special characters.
     """
-    if " ID" in col or " id" in col or "Id" in col or " Id" in col:
+    if "ID" in col or " id" in col or "Id" in col:
         return True
     return False
 

--- a/src/utils/ncit_match_utils.py
+++ b/src/utils/ncit_match_utils.py
@@ -1,14 +1,13 @@
 # - Uses NCIt concept search (keeps synonym/pref-name matching on the API side)
 # - Classifies by prebuilt descendants sets (O(1) membership) + BFS up to 5 hops via parents
 from collections import defaultdict
-from concurrent.futures import wait
 import os
 import re
 import json
 import threading
 import time
 import requests
-from typing import Dict, List, Optional, Tuple, Set
+from typing import Dict, List, Optional, Tuple
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -104,10 +103,7 @@ class NCIClientSync:
         if retry_after_sec and retry_after_sec > 0:
             time.sleep(min(retry_after_sec, 10.0))
 
-    def _get_json(self,
-                  url: str,
-                  params: dict,
-                  retries: int = 0) -> Optional[dict]:
+    def _get_json(self, url: str, params: dict) -> Optional[dict]:
         """GET JSON with adapter-level retries + local smoothing + 429 handling."""
         self._throttle()
         try:


### PR DESCRIPTION
This PR separates the Schema Mapping (SM) and Ontology Mapping (OM) logic to better support different usage environments (e.g., lightweight schema-only mode vs. ontology-enabled mode).

The refactor introduces clear module boundaries and improves modularity, performance, and maintainability.

- Updated imports in demo notebooks and README to use get_schema_engine and get_ontology_engine, enabling selective imports depending on runtime context
- Refactored SchemaMapEngine to lazily load numeric embeddings for efficiency
- Replaced the FAISS-based approach with JSON-based value dictionary loading for value-field matching
- Optimized numeric column detection and value matching logic for better speed and clarity
- Added a minimal requirements_sm.txt for schema mapping dependencies
- Fixed minor utility inconsistencies and improved overall code readability