### PR TITLE
feat: add filter_obsolete flag for obsolete ontology term handling

### DIFF
--- a/src/Engine/ontology_mapping_engine.py
+++ b/src/Engine/ontology_mapping_engine.py
@@ -58,6 +58,7 @@ class OntoMapEngine:
                  s3_strategy: str = None,
                  s3_threshold: float = 0.9,
                  output_dir: str = None,
+                 filter_obsolete: bool = True,
                  **other_params: dict) -> None:
         """
         Initializes the OntoMapEngine class.
@@ -71,6 +72,11 @@ class OntoMapEngine:
             s2_strategy (str, optional): The strategy to use for stage 2 OntoMap. Defaults to 'lm'. Options are 'st' or 'lm'.
             s3_strategy (str, optional): The strategy to use for stage 3 OntoMap. Defaults to None. Options are 'rag', 'rag_bie', or None.
             s3_threshold (float, optional): The threshold for stage 3 OntoMap. Defaults to 0.9.
+            filter_obsolete (bool, optional): If True (default), terms whose
+                label begins with ``obsolete_`` are removed from the corpus,
+                corpus_df, and synonym search results. Set to False for
+                benchmarking against a pinned ontology version whose ground
+                truth still references obsolete labels.
             **other_params (dict): Other parameters to pass to the engine.
         """
         self.s2_method = s2_method
@@ -78,8 +84,21 @@ class OntoMapEngine:
         self.query = query
         self.category = category
         self.output_dir = output_dir
+        self.filter_obsolete = filter_obsolete
         self.corpus = list(
             dict.fromkeys(corpus))  # Remove duplicates while preserving order
+
+        # Filter out obsolete ontology terms (e.g. "obsolete_AIDS") that exist
+        # as valid entries in ontologies like EFO but should not be selected as
+        # matches.  Applies to all stages (exact, LM/ST, synonym, RAG).
+        pre_filter = len(self.corpus)
+        if self.filter_obsolete:
+            self.corpus = [
+                t for t in self.corpus
+                if not t.strip().lower().startswith("obsolete_")
+            ]
+        n_removed = pre_filter - len(self.corpus)
+
         self.topk = topk
         self.s2_strategy = s2_strategy
         self.s3_strategy = s3_strategy
@@ -93,6 +112,16 @@ class OntoMapEngine:
 
         self._test_or_prod = self.other_params['test_or_prod']
         self._logger = logger.custlogger(loglevel='INFO')
+
+        if n_removed:
+            self._logger.info(
+                f"Filtered {n_removed} obsolete terms from corpus "
+                f"({pre_filter} → {len(self.corpus)})"
+            )
+        elif not self.filter_obsolete:
+            self._logger.info(
+                "filter_obsolete=False: keeping obsolete_ terms in corpus"
+            )
 
         corpus_df = self.other_params.get("corpus_df", None)
 
@@ -109,6 +138,17 @@ class OntoMapEngine:
         self.enable_stage_25 = corpus_df is not None
         if corpus_df is not None:
             corpus_df = self._normalize_df(corpus_df, need_code=True)
+
+            # Filter obsolete terms from corpus_df (used by Stages 2.5 and 3)
+            if self.filter_obsolete:
+                obs_mask = corpus_df["official_label"].str.strip().str.lower().str.startswith("obsolete_")
+                n_obs = obs_mask.sum()
+                if n_obs:
+                    corpus_df = corpus_df[~obs_mask].reset_index(drop=True)
+                    self._logger.info(
+                        f"Filtered {n_obs} obsolete rows from corpus_df"
+                    )
+
             self.other_params["corpus_df"] = corpus_df
             self.corpus_s3 = corpus_df["official_label"].astype(
                 str).unique().tolist()
@@ -344,7 +384,8 @@ class OntoMapEngine:
                                         query=non_exact_query_list,
                                         corpus=self.corpus,
                                         topk=self.topk,
-                                        corpus_df=corpus_df)
+                                        corpus_df=corpus_df,
+                                        filter_obsolete=self.filter_obsolete)
         elif strategy == 'rag':
             return omr.OntoMapRAG(method=self.s3_method,
                                   category=self.category,

--- a/src/models/ontology_mapper_synonym.py
+++ b/src/models/ontology_mapper_synonym.py
@@ -16,13 +16,15 @@ class OntoMapSynonym:
                  corpus: List[str],
                  om_strategy: str = 'syn',
                  topk: int = 5,
-                 corpus_df: pd.DataFrame = None):
+                 corpus_df: pd.DataFrame = None,
+                 filter_obsolete: bool = True):
         self.method = method
         self.category = category
         self.query = query
         self.corpus = corpus
         self.topk = topk
         self.corpus_df = corpus_df
+        self.filter_obsolete = filter_obsolete
 
         self.logger = CustomLogger().custlogger(loglevel='INFO')
 
@@ -71,8 +73,12 @@ class OntoMapSynonym:
         k = topk or self.topk
         self.logger.info(f"Searching synonyms for {len(self.query)} queries")
 
-        # Batch search
-        batch_results = self.syn_dict.search_many(self.query, top_k=k)
+        # Over-fetch to compensate for obsolete terms that will be filtered out
+        if self.filter_obsolete:
+            fetch_k = min(k * 3, self.syn_dict.index.ntotal) if self.syn_dict.index else k
+        else:
+            fetch_k = k
+        batch_results = self.syn_dict.search_many(self.query, top_k=fetch_k)
 
         results = []
         for q, matches in zip(self.query, batch_results):
@@ -80,24 +86,26 @@ class OntoMapSynonym:
             curated = (cura_map.get(q, "Not Found") if test_or_prod == 'test'
                        else "Not Available for Prod Environment")
 
-            # Collect top-k matched terms
+            # Collect top-k matched terms, skipping obsolete labels
             top_terms = []
             top_scores = []
 
-            for i in range(k):
-                if i < len(matches):
-                    match = matches[i]
-                    score = match.get('score', 0.0)
+            for match in matches:
+                if len(top_terms) >= k:
+                    break
+                label = match.get('official_label', '')
+                if (self.filter_obsolete
+                        and label.strip().lower().startswith('obsolete_')):
+                    continue
+                score = match.get('score', 0.0)
+                if score >= min_score:
+                    top_terms.append(label)
+                    top_scores.append(score)
 
-                    if score >= min_score:
-                        top_terms.append(match['official_label'])
-                        top_scores.append(score)
-                    else:
-                        top_terms.append(None)
-                        top_scores.append(0.0)
-                else:
-                    top_terms.append(None)
-                    top_scores.append(0.0)
+            # Pad to k entries
+            while len(top_terms) < k:
+                top_terms.append(None)
+                top_scores.append(0.0)
 
             # Calculate match_level: position of curated term in top-k results
             match_level = next(


### PR DESCRIPTION
Filter terms whose label begins with `obsolete_` from the corpus, corpus_df, and synonym search results across all stages (exact, LM/ST, synonym, RAG). Gated by a new `filter_obsolete` parameter on OntoMapEngine and OntoMapSynonym (default True) so version-pinned benchmarks can keep obsolete terms when the ground truth still references them.