### PR TITLE
Add knowledge-DB export/import CLI for sharing prebuilt ontology indexes (#80)

### DIFF
--- a/src/metaharmonizer/scripts/knowledge_db.py
+++ b/src/metaharmonizer/scripts/knowledge_db.py
@@ -1,0 +1,328 @@
+"""Export/import the ontology knowledge DB as a single portable archive (#80).
+
+Building the knowledge DB (SQLite corpus + FAISS indexes) needs a ``UMLS_API_KEY``
+and is slow; independently-built indexes can also drift (GPU float
+non-determinism). "Build once, distribute the artifact" avoids both — a KB
+built on one machine can seed another (e.g. the ``MetaHarmonizer_App``
+``engine_cache`` volume) without a rebuild.
+
+Layout exported (from :data:`metaharmonizer._paths.KNOWLEDGE_DB_DIR`, default
+``~/.metaharmonizer/KnowledgeDb``)::
+
+    vector_db.sqlite                 # consistent snapshot via VACUUM INTO
+    faiss_indexes/<...>.index        # one per (strategy, method, source, category)
+    faiss_indexes/<...>.index.ids.npy
+    manifest.json                    # versions + per-index metadata + sha256
+
+Usage::
+
+    python -m metaharmonizer.scripts.knowledge_db export -o kb.mhkb.tar.gz
+    python -m metaharmonizer.scripts.knowledge_db export -o kb.mhkb.tar.gz --category disease
+    python -m metaharmonizer.scripts.knowledge_db import kb.mhkb.tar.gz [--force]
+
+Correctness notes:
+- The SQLite snapshot uses ``VACUUM INTO`` (never a raw copy) because the live
+  DB runs in WAL mode and a file copy can capture a torn state.
+- ``import`` verifies every file's sha256 against the manifest and hard-fails on
+  mismatch, so the engine never silently serves wrong vectors. It also compares
+  ``kb_format_version`` (hard-fail) and ``package_version`` (warn only), and
+  extracts atomically (temp dir → swap) so a failed import can't corrupt an
+  existing KB. Archive members are path-traversal-checked before extraction.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import sqlite3
+import sys
+import tarfile
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Bumped only when the on-disk KB format or the embedding contract changes in a
+# way that makes an older archive unsafe to load — NOT on every package release.
+KB_FORMAT_VERSION = 1
+
+_MANIFEST_NAME = "manifest.json"
+_SQLITE_NAME = "vector_db.sqlite"
+_FAISS_SUBDIR = "faiss_indexes"
+
+
+# --------------------------------------------------------------------------- #
+# Path resolution (honours env overrides at call time, so tests can redirect)  #
+# --------------------------------------------------------------------------- #
+def _kb_dir() -> Path:
+    from metaharmonizer import _paths
+
+    return Path(os.environ.get("KNOWLEDGE_DB_DIR", _paths.KNOWLEDGE_DB_DIR))
+
+
+def _sqlite_path(kb: Path) -> Path:
+    return kb / _SQLITE_NAME
+
+
+def _faiss_dir(kb: Path) -> Path:
+    return kb / _FAISS_SUBDIR
+
+
+def _package_version() -> str:
+    try:
+        from importlib.metadata import version
+
+        return version("metaharmonizer")
+    except Exception:  # noqa: BLE001
+        return "0.0.0+unknown"
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _parse_index_name(stem: str) -> dict[str, str]:
+    """Parse ``{strategy}_{method}_{ontology_source}_{category}`` from a FAISS
+    index filename stem. Best-effort: unrecognised shapes still round-trip, they
+    just carry a coarser ``raw`` label (custom-corpus hash suffixes fall here)."""
+    parts = stem.split("_")
+    if len(parts) >= 4:
+        strategy, method, source = parts[0], parts[1], parts[2]
+        category = "_".join(parts[3:])
+        return {
+            "strategy": strategy,
+            "method": method,
+            "ontology_source": source,
+            "category": category,
+        }
+    return {"raw": stem}
+
+
+# --------------------------------------------------------------------------- #
+# Export                                                                        #
+# --------------------------------------------------------------------------- #
+def _snapshot_sqlite(src: Path, dst: Path) -> None:
+    """Write a consistent snapshot of the (possibly WAL-mode, possibly open)
+    SQLite DB using ``VACUUM INTO`` — never a raw file copy."""
+    conn = sqlite3.connect(str(src))
+    try:
+        # VACUUM INTO refuses to overwrite an existing file.
+        if dst.exists():
+            dst.unlink()
+        conn.execute("VACUUM INTO ?", (str(dst),))
+    finally:
+        conn.close()
+
+
+def _collect_indexes(faiss_dir: Path, category: str | None) -> list[Path]:
+    if not faiss_dir.is_dir():
+        return []
+    out: list[Path] = []
+    for idx in sorted(faiss_dir.glob("*.index")):
+        meta = _parse_index_name(idx.stem)
+        if category and meta.get("category") != category:
+            continue
+        out.append(idx)
+        ids = idx.with_suffix(".index.ids.npy")
+        if ids.exists():
+            out.append(ids)
+    return out
+
+
+def cmd_export(args: argparse.Namespace) -> int:
+    kb = _kb_dir()
+    sqlite_src = _sqlite_path(kb)
+    if not sqlite_src.exists():
+        print(f"error: no knowledge DB found at {sqlite_src}", file=sys.stderr)
+        return 2
+
+    out_path = Path(args.output)
+    with tempfile.TemporaryDirectory() as tmp:
+        stage = Path(tmp)
+        # 1. Consistent SQLite snapshot.
+        snap = stage / _SQLITE_NAME
+        _snapshot_sqlite(sqlite_src, snap)
+
+        # 2. FAISS indexes (+ ids), optionally filtered by category.
+        faiss_out = stage / _FAISS_SUBDIR
+        faiss_out.mkdir(parents=True, exist_ok=True)
+        indexes = _collect_indexes(_faiss_dir(kb), args.category)
+        for f in indexes:
+            shutil.copy2(f, faiss_out / f.name)
+
+        # 3. Manifest: versions + per-index metadata + sha256 of every file.
+        files_meta: list[dict] = []
+        for f in sorted(stage.rglob("*")):
+            if f.is_file():
+                rel = f.relative_to(stage).as_posix()
+                entry = {"path": rel, "sha256": _sha256(f), "bytes": f.stat().st_size}
+                if rel.endswith(".index"):
+                    entry.update(_parse_index_name(Path(rel).stem))
+                files_meta.append(entry)
+
+        manifest = {
+            "kb_format_version": KB_FORMAT_VERSION,
+            "package_version": _package_version(),
+            "created_utc": datetime.now(timezone.utc).isoformat(),
+            "category_filter": args.category,
+            "files": files_meta,
+        }
+        (stage / _MANIFEST_NAME).write_text(json.dumps(manifest, indent=2))
+
+        # 4. Archive (manifest first so it can be read without full extraction).
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        with tarfile.open(out_path, "w:gz") as tar:
+            tar.add(stage / _MANIFEST_NAME, arcname=_MANIFEST_NAME)
+            for f in sorted(stage.rglob("*")):
+                if f.is_file() and f.name != _MANIFEST_NAME:
+                    tar.add(f, arcname=f.relative_to(stage).as_posix())
+
+    n_idx = sum(1 for m in files_meta if m["path"].endswith(".index"))
+    print(f"exported {n_idx} index(es) + corpus -> {out_path} ({out_path.stat().st_size} bytes)")
+    return 0
+
+
+# --------------------------------------------------------------------------- #
+# Import                                                                        #
+# --------------------------------------------------------------------------- #
+def _safe_extract(tar: tarfile.TarFile, dest: Path) -> None:
+    """Extract with a path-traversal guard: reject absolute paths, ``..`` escapes,
+    and non-regular members."""
+    dest = dest.resolve()
+    for member in tar.getmembers():
+        if not (member.isfile() or member.isdir()):
+            raise ValueError(f"refusing unusual archive member: {member.name}")
+        target = (dest / member.name).resolve()
+        if os.path.commonpath([str(dest), str(target)]) != str(dest):
+            raise ValueError(f"path traversal blocked: {member.name}")
+    # ``filter="data"`` (py>=3.12; backported to 3.10.12/3.11.4) is a second line
+    # of defence on top of the explicit checks above. Fall back cleanly on older
+    # runtimes where the argument is unavailable.
+    try:
+        tar.extractall(dest, filter="data")
+    except TypeError:
+        tar.extractall(dest)  # noqa: S202 — members validated above
+
+
+def cmd_import(args: argparse.Namespace) -> int:
+    archive = Path(args.archive)
+    if not archive.exists():
+        print(f"error: archive not found: {archive}", file=sys.stderr)
+        return 2
+
+    kb = _kb_dir()
+    with tempfile.TemporaryDirectory() as tmp:
+        stage = Path(tmp)
+        with tarfile.open(archive, "r:gz") as tar:
+            _safe_extract(tar, stage)
+
+        manifest_path = stage / _MANIFEST_NAME
+        if not manifest_path.exists():
+            print("error: archive has no manifest.json", file=sys.stderr)
+            return 2
+        manifest = json.loads(manifest_path.read_text())
+
+        # Compatibility: hard-fail on KB-format drift, warn on package drift.
+        fmt = manifest.get("kb_format_version")
+        if fmt != KB_FORMAT_VERSION:
+            print(
+                f"error: KB format version mismatch (archive {fmt} != engine "
+                f"{KB_FORMAT_VERSION}); refusing to import.",
+                file=sys.stderr,
+            )
+            return 3
+        pkg = manifest.get("package_version")
+        if pkg and pkg != _package_version():
+            print(
+                f"warning: archive built with metaharmonizer {pkg}, running "
+                f"{_package_version()} — importing anyway (same KB format).",
+                file=sys.stderr,
+            )
+
+        # Verify every file's checksum before touching the live KB.
+        for entry in manifest.get("files", []):
+            f = stage / entry["path"]
+            if not f.exists():
+                print(f"error: manifest lists missing file: {entry['path']}", file=sys.stderr)
+                return 3
+            actual = _sha256(f)
+            if actual != entry["sha256"]:
+                print(
+                    f"error: checksum mismatch for {entry['path']} — corrupt archive; "
+                    "aborting so the engine never serves wrong vectors.",
+                    file=sys.stderr,
+                )
+                return 3
+
+        # Refuse to clobber an existing KB unless --force.
+        target_sqlite = _sqlite_path(kb)
+        if target_sqlite.exists() and not args.force:
+            print(
+                f"error: a knowledge DB already exists at {kb}; pass --force to replace it.",
+                file=sys.stderr,
+            )
+            return 4
+
+        # Atomic-ish install: build the new KB tree in a sibling temp dir, then
+        # swap directories so a crash mid-copy can't leave a half KB.
+        kb.parent.mkdir(parents=True, exist_ok=True)
+        staged_kb = Path(tempfile.mkdtemp(prefix=".kb_new_", dir=str(kb.parent)))
+        try:
+            shutil.copy2(stage / _SQLITE_NAME, staged_kb / _SQLITE_NAME)
+            src_faiss = stage / _FAISS_SUBDIR
+            if src_faiss.is_dir():
+                shutil.copytree(src_faiss, staged_kb / _FAISS_SUBDIR)
+            shutil.copy2(manifest_path, staged_kb / _MANIFEST_NAME)
+
+            backup = None
+            if kb.exists():
+                backup = kb.parent / (kb.name + ".old")
+                if backup.exists():
+                    shutil.rmtree(backup)
+                os.replace(kb, backup)
+            os.replace(staged_kb, kb)
+            if backup and backup.exists():
+                shutil.rmtree(backup, ignore_errors=True)
+        except Exception:
+            shutil.rmtree(staged_kb, ignore_errors=True)
+            raise
+
+    print(f"imported knowledge DB -> {kb}")
+    return 0
+
+
+# --------------------------------------------------------------------------- #
+# CLI                                                                          #
+# --------------------------------------------------------------------------- #
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m metaharmonizer.scripts.knowledge_db",
+        description="Export/import the ontology knowledge DB as a portable archive.",
+    )
+    sub = p.add_subparsers(dest="command", required=True)
+
+    exp = sub.add_parser("export", help="Bundle the knowledge DB into an archive.")
+    exp.add_argument("-o", "--output", required=True, help="Output .mhkb.tar.gz path.")
+    exp.add_argument("--category", default=None, help="Only export indexes for this category.")
+    exp.set_defaults(func=cmd_export)
+
+    imp = sub.add_parser("import", help="Install a knowledge-DB archive.")
+    imp.add_argument("archive", help="Path to a .mhkb.tar.gz archive.")
+    imp.add_argument("--force", action="store_true", help="Replace an existing KB.")
+    imp.set_defaults(func=cmd_import)
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/metaharmonizer/scripts/knowledge_db.py
+++ b/src/metaharmonizer/scripts/knowledge_db.py
@@ -59,15 +59,19 @@ _FAISS_SUBDIR = "faiss_indexes"
 def _kb_dir() -> Path:
     from metaharmonizer import _paths
 
-    return Path(os.environ.get("KNOWLEDGE_DB_DIR", _paths.KNOWLEDGE_DB_DIR))
+    return Path(os.environ.get("KNOWLEDGE_DB_DIR", str(_paths.DEFAULT_KNOWLEDGE_DB_DIR)))
 
 
 def _sqlite_path(kb: Path) -> Path:
-    return kb / _SQLITE_NAME
+    # Mirror the engine's own resolution (metaharmonizer._paths): the SQLite
+    # store and FAISS index dir can be relocated independently of
+    # KNOWLEDGE_DB_DIR via VECTOR_DB_PATH / FAISS_INDEX_DIR, so we cannot assume
+    # they live under the KB dir.
+    return Path(os.environ.get("VECTOR_DB_PATH", str(kb / _SQLITE_NAME)))
 
 
 def _faiss_dir(kb: Path) -> Path:
-    return kb / _FAISS_SUBDIR
+    return Path(os.environ.get("FAISS_INDEX_DIR", str(kb / _FAISS_SUBDIR)))
 
 
 def _package_version() -> str:
@@ -88,18 +92,25 @@ def _sha256(path: Path) -> str:
 
 
 def _parse_index_name(stem: str) -> dict[str, str]:
-    """Parse ``{strategy}_{method}_{ontology_source}_{category}`` from a FAISS
-    index filename stem. Best-effort: unrecognised shapes still round-trip, they
-    just carry a coarser ``raw`` label (custom-corpus hash suffixes fall here)."""
+    """Best-effort parse of a FAISS index filename stem.
+
+    The engine builds names as
+    ``{strategy}_{method}_{ontology_source}_{category}{table_suffix}`` where the
+    embedding *method* itself may contain underscores: a method such as
+    ``sap-bert`` is written to disk as ``sap_bert`` (``method.replace('-', '_')``
+    in ``faiss_sqlite_pipeline.py``). ``ontology_source`` and ``category`` are
+    validated single-token identifiers, so we anchor from the right — category is
+    the last token, source the second-last, strategy the first — and treat
+    everything in between as the variable-length method. A naive left-to-right
+    split would mis-read ``rag_sap_bert_ncit_disease`` as category ``ncit_disease``.
+    Unrecognised shapes still round-trip, carrying a coarser ``raw`` label."""
     parts = stem.split("_")
     if len(parts) >= 4:
-        strategy, method, source = parts[0], parts[1], parts[2]
-        category = "_".join(parts[3:])
         return {
-            "strategy": strategy,
-            "method": method,
-            "ontology_source": source,
-            "category": category,
+            "strategy": parts[0],
+            "method": "_".join(parts[1:-2]),
+            "ontology_source": parts[-2],
+            "category": parts[-1],
         }
     return {"raw": stem}
 
@@ -191,6 +202,16 @@ def cmd_export(args: argparse.Namespace) -> int:
 # --------------------------------------------------------------------------- #
 # Import                                                                        #
 # --------------------------------------------------------------------------- #
+def _atomic_install(src: Path, dst: Path) -> None:
+    """Copy ``src`` to a sibling temp file then ``os.replace`` it into ``dst`` so
+    a concurrent reader never observes a partially-written file (``os.replace``
+    is atomic on the same filesystem)."""
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dst.parent / (dst.name + ".partial")
+    shutil.copy2(src, tmp)
+    os.replace(tmp, dst)
+
+
 def _safe_extract(tar: tarfile.TarFile, dest: Path) -> None:
     """Extract with a path-traversal guard: reject absolute paths, ``..`` escapes,
     and non-regular members."""
@@ -262,38 +283,31 @@ def cmd_import(args: argparse.Namespace) -> int:
 
         # Refuse to clobber an existing KB unless --force.
         target_sqlite = _sqlite_path(kb)
+        target_faiss = _faiss_dir(kb)
         if target_sqlite.exists() and not args.force:
             print(
-                f"error: a knowledge DB already exists at {kb}; pass --force to replace it.",
+                f"error: a knowledge DB already exists at {target_sqlite}; "
+                "pass --force to replace it.",
                 file=sys.stderr,
             )
             return 4
 
-        # Atomic-ish install: build the new KB tree in a sibling temp dir, then
-        # swap directories so a crash mid-copy can't leave a half KB.
-        kb.parent.mkdir(parents=True, exist_ok=True)
-        staged_kb = Path(tempfile.mkdtemp(prefix=".kb_new_", dir=str(kb.parent)))
-        try:
-            shutil.copy2(stage / _SQLITE_NAME, staged_kb / _SQLITE_NAME)
-            src_faiss = stage / _FAISS_SUBDIR
-            if src_faiss.is_dir():
-                shutil.copytree(src_faiss, staged_kb / _FAISS_SUBDIR)
-            shutil.copy2(manifest_path, staged_kb / _MANIFEST_NAME)
+        # Install into the engine's real target locations. Checksums are already
+        # verified above, so we replace each file in place with os.replace
+        # (atomic on the same filesystem). We install per-file rather than
+        # swapping a single directory because VECTOR_DB_PATH / FAISS_INDEX_DIR
+        # may be relocated independently of KNOWLEDGE_DB_DIR.
+        target_sqlite.parent.mkdir(parents=True, exist_ok=True)
+        target_faiss.mkdir(parents=True, exist_ok=True)
+        _atomic_install(stage / _SQLITE_NAME, target_sqlite)
+        src_faiss = stage / _FAISS_SUBDIR
+        if src_faiss.is_dir():
+            for f in sorted(src_faiss.iterdir()):
+                if f.is_file():
+                    _atomic_install(f, target_faiss / f.name)
+        _atomic_install(manifest_path, target_sqlite.parent / _MANIFEST_NAME)
 
-            backup = None
-            if kb.exists():
-                backup = kb.parent / (kb.name + ".old")
-                if backup.exists():
-                    shutil.rmtree(backup)
-                os.replace(kb, backup)
-            os.replace(staged_kb, kb)
-            if backup and backup.exists():
-                shutil.rmtree(backup, ignore_errors=True)
-        except Exception:
-            shutil.rmtree(staged_kb, ignore_errors=True)
-            raise
-
-    print(f"imported knowledge DB -> {kb}")
+    print(f"imported knowledge DB -> {target_sqlite.parent}")
     return 0
 
 

--- a/tests/test_knowledge_db_portability.py
+++ b/tests/test_knowledge_db_portability.py
@@ -1,0 +1,131 @@
+"""Round-trip + safety tests for the knowledge-DB export/import CLI (#80).
+
+These use a synthetic KNOWLEDGE_DB_DIR (a tiny real SQLite file + fake FAISS
+index blobs), so no UMLS_API_KEY or built corpus is required.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from metaharmonizer.scripts import knowledge_db as kb
+
+
+def _make_kb(root: Path) -> Path:
+    """Create a minimal fake knowledge DB under ``root`` and return its dir."""
+    kbdir = root / "KnowledgeDb"
+    (kbdir / "faiss_indexes").mkdir(parents=True)
+    # A real (tiny) SQLite DB so VACUUM INTO works.
+    conn = sqlite3.connect(str(kbdir / "vector_db.sqlite"))
+    conn.execute("CREATE TABLE concept (id INTEGER, term TEXT)")
+    conn.execute("INSERT INTO concept VALUES (1, 'lung')")
+    conn.commit()
+    conn.close()
+    # Fake FAISS index pair for one (strategy, method, source, category).
+    idx = kbdir / "faiss_indexes" / "rag_sap-bert_ncit_disease.index"
+    idx.write_bytes(b"FAKE-FAISS-INDEX-BYTES")
+    idx.with_suffix(".index.ids.npy").write_bytes(b"FAKE-IDS")
+    return kbdir
+
+
+@pytest.fixture
+def kb_env(tmp_path, monkeypatch):
+    kbdir = _make_kb(tmp_path / "src")
+    monkeypatch.setenv("KNOWLEDGE_DB_DIR", str(kbdir))
+    return kbdir
+
+
+def test_export_then_import_roundtrip(tmp_path, kb_env, monkeypatch):
+    archive = tmp_path / "kb.mhkb.tar.gz"
+    assert kb.main(["export", "-o", str(archive)]) == 0
+    assert archive.exists()
+
+    # Import into a fresh, empty KNOWLEDGE_DB_DIR.
+    dest = tmp_path / "dest" / "KnowledgeDb"
+    monkeypatch.setenv("KNOWLEDGE_DB_DIR", str(dest))
+    assert kb.main(["import", str(archive)]) == 0
+
+    assert (dest / "vector_db.sqlite").exists()
+    assert (dest / "faiss_indexes" / "rag_sap-bert_ncit_disease.index").exists()
+    assert (dest / "faiss_indexes" / "rag_sap-bert_ncit_disease.index.ids.npy").exists()
+    # The restored SQLite is queryable.
+    conn = sqlite3.connect(str(dest / "vector_db.sqlite"))
+    assert conn.execute("SELECT term FROM concept WHERE id=1").fetchone()[0] == "lung"
+    conn.close()
+
+
+def test_manifest_records_index_metadata(tmp_path, kb_env):
+    archive = tmp_path / "kb.mhkb.tar.gz"
+    kb.main(["export", "-o", str(archive)])
+    with tarfile.open(archive) as tar:
+        manifest = json.loads(tar.extractfile("manifest.json").read())
+    assert manifest["kb_format_version"] == kb.KB_FORMAT_VERSION
+    idx = next(f for f in manifest["files"] if f["path"].endswith(".index"))
+    assert idx["ontology_source"] == "ncit"
+    assert idx["category"] == "disease"
+    assert idx["strategy"] == "rag"
+
+
+def test_category_filter_excludes_other_indexes(tmp_path, kb_env):
+    # Add a second-category index.
+    (kb_env / "faiss_indexes" / "rag_sap-bert_uberon_bodysite.index").write_bytes(b"X")
+    archive = tmp_path / "kb.mhkb.tar.gz"
+    kb.main(["export", "-o", str(archive), "--category", "disease"])
+    with tarfile.open(archive) as tar:
+        names = tar.getnames()
+    assert any("ncit_disease.index" in n for n in names)
+    assert not any("uberon_bodysite.index" in n for n in names)
+
+
+def test_import_detects_checksum_mismatch(tmp_path, kb_env, monkeypatch, capsys):
+    archive = tmp_path / "kb.mhkb.tar.gz"
+    kb.main(["export", "-o", str(archive)])
+
+    # Tamper: rewrite the sqlite entry inside the archive, keep the old manifest.
+    tampered = tmp_path / "bad.mhkb.tar.gz"
+    with tarfile.open(archive) as src, tarfile.open(tampered, "w:gz") as dst:
+        for m in src.getmembers():
+            data = src.extractfile(m).read() if m.isfile() else b""
+            if m.name == "vector_db.sqlite":
+                data = data + b"CORRUPT"
+                m.size = len(data)
+            import io
+
+            dst.addfile(m, io.BytesIO(data))
+
+    dest = tmp_path / "dest" / "KnowledgeDb"
+    monkeypatch.setenv("KNOWLEDGE_DB_DIR", str(dest))
+    rc = kb.main(["import", str(tampered)])
+    assert rc == 3
+    assert "checksum mismatch" in capsys.readouterr().err
+
+
+def test_import_blocks_path_traversal(tmp_path, monkeypatch, capsys):
+    # Hand-craft a malicious archive with a '..' member.
+    evil = tmp_path / "evil.mhkb.tar.gz"
+    payload = tmp_path / "payload"
+    payload.write_text("pwned")
+    with tarfile.open(evil, "w:gz") as tar:
+        tar.add(payload, arcname="../escape.txt")
+        # minimal manifest so we reach extraction first
+    dest = tmp_path / "dest" / "KnowledgeDb"
+    monkeypatch.setenv("KNOWLEDGE_DB_DIR", str(dest))
+    with pytest.raises(ValueError, match="path traversal"):
+        kb.main(["import", str(evil)])
+
+
+def test_import_refuses_existing_without_force(tmp_path, kb_env, monkeypatch, capsys):
+    archive = tmp_path / "kb.mhkb.tar.gz"
+    kb.main(["export", "-o", str(archive)])
+    dest = _make_kb(tmp_path / "dest2")  # a KB already exists here
+    monkeypatch.setenv("KNOWLEDGE_DB_DIR", str(dest))
+    assert kb.main(["import", str(archive)]) == 4
+    assert "already exists" in capsys.readouterr().err
+    # With --force it succeeds.
+    assert kb.main(["import", str(archive), "--force"]) == 0

--- a/tests/test_knowledge_db_portability.py
+++ b/tests/test_knowledge_db_portability.py
@@ -27,8 +27,11 @@ def _make_kb(root: Path) -> Path:
     conn.execute("INSERT INTO concept VALUES (1, 'lung')")
     conn.commit()
     conn.close()
-    # Fake FAISS index pair for one (strategy, method, source, category).
-    idx = kbdir / "faiss_indexes" / "rag_sap-bert_ncit_disease.index"
+    # Fake FAISS index pair. The name matches what the engine actually writes:
+    # faiss_sqlite_pipeline builds `{strategy}_{method}_{source}_{category}` and
+    # cleans the method with `.replace('-', '_')`, so `sap-bert` lands on disk as
+    # `sap_bert` (an underscore *inside* the method token).
+    idx = kbdir / "faiss_indexes" / "rag_sap_bert_ncit_disease.index"
     idx.write_bytes(b"FAKE-FAISS-INDEX-BYTES")
     idx.with_suffix(".index.ids.npy").write_bytes(b"FAKE-IDS")
     return kbdir
@@ -52,8 +55,8 @@ def test_export_then_import_roundtrip(tmp_path, kb_env, monkeypatch):
     assert kb.main(["import", str(archive)]) == 0
 
     assert (dest / "vector_db.sqlite").exists()
-    assert (dest / "faiss_indexes" / "rag_sap-bert_ncit_disease.index").exists()
-    assert (dest / "faiss_indexes" / "rag_sap-bert_ncit_disease.index.ids.npy").exists()
+    assert (dest / "faiss_indexes" / "rag_sap_bert_ncit_disease.index").exists()
+    assert (dest / "faiss_indexes" / "rag_sap_bert_ncit_disease.index.ids.npy").exists()
     # The restored SQLite is queryable.
     conn = sqlite3.connect(str(dest / "vector_db.sqlite"))
     assert conn.execute("SELECT term FROM concept WHERE id=1").fetchone()[0] == "lung"
@@ -70,11 +73,12 @@ def test_manifest_records_index_metadata(tmp_path, kb_env):
     assert idx["ontology_source"] == "ncit"
     assert idx["category"] == "disease"
     assert idx["strategy"] == "rag"
+    assert idx["method"] == "sap_bert"
 
 
 def test_category_filter_excludes_other_indexes(tmp_path, kb_env):
     # Add a second-category index.
-    (kb_env / "faiss_indexes" / "rag_sap-bert_uberon_bodysite.index").write_bytes(b"X")
+    (kb_env / "faiss_indexes" / "rag_sap_bert_uberon_bodysite.index").write_bytes(b"X")
     archive = tmp_path / "kb.mhkb.tar.gz"
     kb.main(["export", "-o", str(archive), "--category", "disease"])
     with tarfile.open(archive) as tar:


### PR DESCRIPTION
## Summary

Implements #80 — a CLI to **export the ontology knowledge DB (SQLite corpus + FAISS indexes) into a single portable archive, and import it on another machine.** Lets a KB built once (needs `UMLS_API_KEY`, slow, GPU-float-nondeterministic) be shared with collaborators and used to seed the `MetaHarmonizer_App` `engine_cache` volume — no per-machine rebuild.

```bash
python -m metaharmonizer.scripts.knowledge_db export -o kb.mhkb.tar.gz
python -m metaharmonizer.scripts.knowledge_db export -o kb.mhkb.tar.gz --category disease
python -m metaharmonizer.scripts.knowledge_db import kb.mhkb.tar.gz [--force]
```

## What's included

- `src/metaharmonizer/scripts/knowledge_db.py` — `export` / `import` subcommands, following the `scripts/*` + argparse + `python -m` convention (mirrors `bootstrap_data.py`).
- `tests/test_knowledge_db_portability.py` — round-trip, manifest metadata, `--category` filter, checksum-mismatch detection, path-traversal guard, and existing-KB/`--force` behaviour. Uses a synthetic `KNOWLEDGE_DB_DIR` (tiny real SQLite + fake index blobs), so **no `UMLS_API_KEY` or built corpus is needed** to run them.

## Design decisions (per the issue's correctness requirements)

- **Consistent SQLite snapshot** via `VACUUM INTO` — never a raw copy, because the live DB runs in WAL mode and a file copy can capture a torn state.
- **Manifest** records `kb_format_version`, `package_version`, per-index `{strategy, method, ontology_source, category}` (parsed right-to-left from the filename, since the embedding method itself can contain underscores — `sap-bert` is written to disk as `sap_bert`), and `sha256` + size of every file. Written **first** in the archive so it can be read without full extraction.
- **Import verification** — every file's `sha256` is checked before the live KB is touched; hard-fail on mismatch so the engine never silently serves wrong vectors.
- **`kb_format_version` split from `package_version`** — hard-fail on KB-format drift, **warn** on package drift. A KB built on `0.4.0` shouldn't be rejected just because you're on `0.4.3`; only an actual on-disk/embedding-format change bumps `KB_FORMAT_VERSION`.
- **Atomic install** — after extraction and checksum verification, each file is copied to a sibling temp path and `os.replace`d into its target (atomic on the same filesystem), so a reader never sees a half-written file. Files land in the engine's real locations, honoring the `VECTOR_DB_PATH` / `FAISS_INDEX_DIR` overrides (matching `_paths.py`) rather than assuming a fixed subdirectory.
- **Path-traversal guard** on extraction (reject absolute paths / `..` / non-regular members), plus `filter="data"` as a second line of defence on Python ≥3.12 (graceful fallback on older runtimes).
- **`--category`** exports a subset. Custom-corpus hash-suffixed index names still round-trip (they carry a coarser label; `--category` matching them is left as the follow-up the issue notes).

## Out of scope (matches the issue)

`--merge`, hash-suffix-aware `--category`, model-cache bundling, and remote (S3/HF) distribution are intentionally not included — local archive first.

## App-side integration (separate repo)

The `MetaHarmonizer_App` compose profile that runs `... knowledge_db import` against the `engine_cache` volume (and, on our side, pulls the snapshot from object storage before `docker compose up`) will live in the app repo — happy to wire that once this CLI lands.

## Testing

```
pytest tests/test_knowledge_db_portability.py -q
# 6 passed
```
