### PR TITLE
Fix UBERON corpus-build crash: skip cross-ontology xref prefixes in _partition_codes

### DIFF
--- a/src/metaharmonizer/engine/ontology_mapping_engine.py
+++ b/src/metaharmonizer/engine/ontology_mapping_engine.py
@@ -672,11 +672,13 @@ class OntoMapEngine:
                 ont = "ncit"
             groups.setdefault(ont, []).append(code)
         if unknown:
-            raise ValueError(
-                f"Unknown ontology prefix in codes: {unknown[:5]}"
-                f"{'...' if len(unknown) > 5 else ''}. "
-                f"Supported prefixes: {sorted(PREFIX_TO_ONTOLOGY.keys())} "
-                f"and bare NCI codes (e.g. C12345)."
+            logger.custlogger(loglevel="INFO").warning(
+                "Skipping %d code(s) with unsupported ontology prefix "
+                "(cross-ontology xrefs such as COB_/NCBITaxon_ that are not the "
+                "mapping target): %s%s",
+                len(unknown),
+                unknown[:5],
+                "..." if len(unknown) > 5 else "",
             )
         return groups
 

--- a/tests/test_partition_codes.py
+++ b/tests/test_partition_codes.py
@@ -1,6 +1,4 @@
 """Tests for OntoMapEngine._partition_codes — code prefix routing logic."""
-import pytest
-
 from metaharmonizer.engine.ontology_mapping_engine import OntoMapEngine
 
 
@@ -41,6 +39,14 @@ class TestPartitionCodes:
         assert "cl" in result
         assert "chebi" in result
 
-    def test_unknown_prefix_raises(self):
-        with pytest.raises(ValueError, match="Unknown ontology prefix"):
-            OntoMapEngine._partition_codes(["XYZ_12345"])
+    def test_unknown_prefix_is_skipped(self):
+        """Cross-ontology xref codes that UBERON legitimately imports (e.g. COB_,
+        NCBITaxon_) are skipped, not fatal — a real corpus build must not crash
+        on them."""
+        result = OntoMapEngine._partition_codes(
+            ["C12345", "UBERON_0001062", "COB_0000021", "NCBITaxon_10045", "XYZ_1"]
+        )
+        assert result == {"ncit": ["C12345"], "uberon": ["UBERON_0001062"]}
+
+    def test_all_unknown_prefixes_returns_empty(self):
+        assert OntoMapEngine._partition_codes(["COB_0000021", "NCBITaxon_10045"]) == {}


### PR DESCRIPTION
## Summary

Fix an end-to-end crash when building an ontology corpus whose codes include
**cross-ontology cross-references** — e.g. UBERON body-site terms that import
`COB_*` (Core Ontology for Biology) or `NCBITaxon_*` (NCBI Taxonomy) codes.

`OntoMapEngine._partition_codes` groups a corpus's `clean_code`s by ontology
source and **hard-raises `ValueError`** for any prefix not in
`PREFIX_TO_ONTOLOGY`. That dict lists only the mappable target ontologies
(`BFO, CHEBI, CL, DOID, EFO, GO, HP, MONDO, OBI, Orphanet, PATO, UBERON`) plus
bare NCI codes — so a legitimate UBERON build aborts as soon as one xref code
appears.

### Reproduce (current `main`)

```python
from metaharmonizer.engine.ontology_mapping_engine import OntoMapEngine
OntoMapEngine._partition_codes(["C12345", "UBERON_0001062", "COB_0000021", "NCBITaxon_10045"])
# ValueError: Unknown ontology prefix in codes: ['COB_0000021', 'NCBITaxon_10045']. ...
```

`_ensure_concept_tables` → `_partition_codes(corpus_df["clean_code"].unique())`,
so this takes down the whole `UBERON-bodysite` corpus build.

## Fix

Skip the unknown-prefix codes (with a warning) instead of raising. Those codes
belong to ontologies that are **not the mapping target** and can't be resolved
against the corpus being built, so dropping them is correct — the build now
completes and maps against the real UBERON terms.

```python
        if unknown:
            logger.custlogger(loglevel="INFO").warning(
                "Skipping %d code(s) with unsupported ontology prefix ...", len(unknown), unknown[:5], ...
            )
        return groups
```

### Why *skip*, not add `COB`/`NCBITaxon` to `PREFIX_TO_ONTOLOGY`

`NCBITaxon` is the NCBI **species taxonomy** and `COB` is an **upper ontology** —
neither is an anatomy/body-site ontology. Adding them would make the engine try
to build/fetch those corpora (NCBITaxon is enormous) and would pollute body-site
results with taxonomy/upper-ontology terms. They only appear as xrefs, so
skipping them is the correct, minimal behavior.

## Tests

`tests/test_partition_codes.py` asserts foreign prefixes are skipped, bare codes
map to `ncit`, and an all-foreign input returns `{}` — no `ValueError`.
