### PR TITLE
fix(ontology): exact matches wrongly returned as "Not Found" in prod mode

### DIFF
--- a/src/metaharmonizer/engine/ontology_mapping_engine.py
+++ b/src/metaharmonizer/engine/ontology_mapping_engine.py
@@ -1371,9 +1371,9 @@ class OntoMapEngine:
 
         # Create DataFrame for Stage 1 matches
         exact_df = pd.DataFrame({'original_value': stage1_matches})
-              if self._test_or_prod == 'test':
+        if self._test_or_prod == 'test':
             exact_df['curated_ontology'] = exact_df['original_value'].map(
-                self.ground_truth_map).fillna(exact_df['original_value'])
+            self.ground_truth_map).fillna(exact_df['original_value'])
         else:
             # Prod has no real ground truth: ground_truth_map is a
             # {query: "Not Found"} placeholder, so an exact corpus hit IS the

--- a/src/metaharmonizer/engine/ontology_mapping_engine.py
+++ b/src/metaharmonizer/engine/ontology_mapping_engine.py
@@ -1371,8 +1371,14 @@ class OntoMapEngine:
 
         # Create DataFrame for Stage 1 matches
         exact_df = pd.DataFrame({'original_value': stage1_matches})
-        exact_df['curated_ontology'] = exact_df['original_value'].map(
-            self.ground_truth_map).fillna(exact_df['original_value'])
+              if self._test_or_prod == 'test':
+            exact_df['curated_ontology'] = exact_df['original_value'].map(
+                self.ground_truth_map).fillna(exact_df['original_value'])
+        else:
+            # Prod has no real ground truth: ground_truth_map is a
+            # {query: "Not Found"} placeholder, so an exact corpus hit IS the
+            # correct label — use the matched value instead of clobbering it.
+            exact_df['curated_ontology'] = exact_df['original_value']
         exact_df['match_level'] = 1
         exact_df['stage'] = 1.0
         exact_df['match1'] = exact_df['curated_ontology']


### PR DESCRIPTION
## Summary
In **prod mode** (no `ground_truth_map`), `OntoMapEngine.run()` returns every Stage-1
**exact** corpus match as `match1 = "Not Found"` at `match1_score = 1.00` — max confidence
on a wrong answer. Queries that exactly match a corpus term are silently dropped.

## Root cause
In prod, the engine fills a placeholder map `{q: "Not Found" for q in self.query}`.
`_exact_matching()` returns the raw query strings, so each is a key in that map. Stage 1
maps through it and copies the result into `match1`:

```python
exact_df['curated_ontology'] = exact_df['original_value'].map(
    self.ground_truth_map).fillna(exact_df['original_value'])
...
exact_df['match1'] = exact_df['curated_ontology']   # -> "Not Found" in prod
```

`.map()` hits every key, so `.fillna(...)` never fires. (Stage 1 is the only stage that
copies `curated_ontology` into `match1`; Stages 2–4 are unaffected.)

## Fix
An exact hit *is* the correct label in prod, so use `original_value`; keep the ground-truth
lookup only in test mode:

```python
if self._test_or_prod == 'test':
    exact_df['curated_ontology'] = exact_df['original_value'].map(
        self.ground_truth_map).fillna(exact_df['original_value'])
else:
    exact_df['curated_ontology'] = exact_df['original_value']
```

## Impact
- Prod exact matches return the matched term at score 1.0 instead of `"Not Found"`.
- Test mode unchanged.